### PR TITLE
Fix screenshot on windows

### DIFF
--- a/lib/controllers.js
+++ b/lib/controllers.js
@@ -142,16 +142,13 @@ controllers.findElements = function *(strategy, selector, elementId) {
 };
 
 controllers.getScreenshot = function *() {
-  const swapFile = temp.openSync({
+  const swapFilePath = temp.path({
     prefix: `${pkg.name}-screenshot`,
     suffix: '.png'
   });
-  const swapFilePath = swapFile.path;
   const remoteFile = `${this.adb.getTmpDir()}/screenshot.png`;
   const cmd = `/system/bin/rm ${remoteFile}; /system/bin/screencap -p ${remoteFile}`;
   yield this.adb.shell(cmd);
-
-  _.rimraf(swapFilePath);
 
   yield this.adb.pull(remoteFile, swapFilePath);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "macaca-android",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "description": "Macaca Android driver",
   "keywords": [
     "android"


### PR DESCRIPTION
由于 windows 上创建的文件不一定能删除成功，导致无法复制到指定地址，所以改为只创建一个临时地址，并不创建实际的文件，这样不影响后续从 Android 端来拉取文件。
https://github.com/isaacs/rimraf/issues/72