### PR TITLE
处理properties[name]为false返回null的问题

### DIFF
--- a/lib/controllers.js
+++ b/lib/controllers.js
@@ -161,7 +161,7 @@ controllers.getProperty = function *(elementId, name) {
     }
   });
   var properties = JSON.parse(res);
-  return properties[name] || null;
+  return properties[name] === undefined || properties[name] === false || properties[name] ? properties[name] : null;
 };
 
 controllers.getSource = function *() {


### PR DESCRIPTION
properties[name]为false的时候应该返回false 
比如说enabled属性 返回Null还是很奇怪的